### PR TITLE
Bump rewrite-clj version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Leiningen plugin for setting (rewriting) the project.clj version according to 
 
 ## Usage
 
-Put `[lein-version-spec "0.0.4]` into the `:plugins` vector of your project.clj.
+Put `[lein-version-spec "0.0.5]` into the `:plugins` vector of your project.clj.
 
 Add a `:version-spec "0.1.~{:env/circle_build_num}"` to your project.clj. Then run
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject lein-version-spec "0.0.4"
+(defproject lein-version-spec "0.0.5"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/core.incubator "0.1.1"]
-                 [rewrite-clj "0.3.5"]]
+                 [rewrite-clj "0.4.11"]]
   :eval-in-leiningen true)


### PR DESCRIPTION
Annoyingly, `rewrite-clj` is now a dependency of `cljfmt` which in turn is a dependency of `cider-nrepl`. This has only just been introduced in `master`, but eventually will be released. Unfortunately the version pulled into Circle's dependencies causes the new `cider-nrepl` to throw a compiler exception and crash.

The parts of the API used in this plugin haven't changed and a command line test indicates that it works.

I'd like to take care of this now rather than later, because bit rot only gets worse, never better, and also because I like to use `-SNAPSHOT` versions of `cider` and `cider-nrepl`.
